### PR TITLE
Fix exclusiveMaximum/Minimum model

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -421,7 +421,16 @@ class FlaskPydanticSpec:
         for key, value in property.items():
             for prop, val in value.items():
                 if prop in allowed_fields:
-                    result[key][prop] = val
+                    # a hack to convert exclusiveMaximum/Minimum to valid openapi spec
+                    # https://github.com/tiangolo/fastapi/issues/240
+                    if prop == "exclusiveMinimum":
+                        result[key][prop] = True
+                        result[key]["minimum"] = val
+                    elif prop == "exclusiveMaximum":
+                        result[key][prop] = True
+                        result[key]["maximum"] = val
+                    else:
+                        result[key][prop] = val
 
         return result
 


### PR DESCRIPTION
https://github.com/tiangolo/fastapi/issues/3541
https://github.com/tiangolo/fastapi/issues/240

There is an issue that if the pydantic model is set with gt/lt, the generated model doesn't company with openapi format. 
This PR puts a fix for this issue. Check above links for more context.