### PR TITLE
Upgrade from 0.3.1 to 0.4.1

### DIFF
--- a/.github/workflows/test-static-analysis.yml
+++ b/.github/workflows/test-static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,17 @@
 .. currentmodule:: flask-pydantic-spec
-VERSION 0.4.0
+VERSION 0.4.1
 -------------
 
 Release 2022-11-14
 
 - Add ability to parse nested multipart form requests with JSON strings under keys
+
+
+VERSION 0.4.0
+-------------
+
+Release 2022-11-14
+
 - Drop support for Python 3.6
 
 VERSION 0.3.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,12 @@
 .. currentmodule:: flask-pydantic-spec
+VERSION 0.4.0
+-------------
+
+Release 2022-11-14
+
+- Add ability to parse nested multipart form requests with JSON strings under keys
+- Drop support for Python 3.6
+
 VERSION 0.3.1
 -------------
 

--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -16,6 +16,7 @@ from flask import (
     Response as FlaskResponse,
 )
 from werkzeug.datastructures import Headers
+from werkzeug.routing import parse_converter_args
 
 from .config import Config
 from .page import PAGES
@@ -57,7 +58,6 @@ class FlaskBackend:
             yield method, func
 
     def parse_path(self, route: Any) -> Tuple[str, List[Any]]:
-        from werkzeug.routing import parse_rule, parse_converter_args
 
         subs = []
         parameters = []

--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -16,12 +16,12 @@ from flask import (
     Response as FlaskResponse,
 )
 from werkzeug.datastructures import Headers
-from werkzeug.routing import parse_converter_args
+from werkzeug.routing import Rule, parse_converter_args
 
 from .config import Config
 from .page import PAGES
 from .types import ResponseBase, RequestBase
-from .utils import parse_multi_dict
+from .utils import parse_multi_dict, parse_rule
 
 
 @dataclass
@@ -57,12 +57,12 @@ class FlaskBackend:
         for method in route.methods:
             yield method, func
 
-    def parse_path(self, route: Any) -> Tuple[str, List[Any]]:
+    def parse_path(self, route: Rule) -> Tuple[str, List[Any]]:
 
         subs = []
         parameters = []
 
-        for converter, arguments, variable in parse_rule(str(route)):
+        for converter, arguments, variable in parse_rule(route):
             if converter is None:
                 subs.append(variable)
                 continue
@@ -150,7 +150,7 @@ class FlaskBackend:
             else:
                 parsed_body = request.get_json() or {}
         elif request.content_type and "multipart/form-data" in request.content_type:
-            parsed_body = request.form or {}
+            parsed_body = parse_multi_dict(request.form) if request.form else {}
         else:
             parsed_body = request.get_data() or {}
         req_headers: Optional[Headers] = request.headers or None

--- a/flask_pydantic_spec/types.py
+++ b/flask_pydantic_spec/types.py
@@ -10,17 +10,17 @@ class ResponseBase:
     """
 
     def has_model(self) -> bool:
-        ...
+        raise NotImplemented
 
     def find_model(self, code: int) -> Optional[Type[BaseModel]]:
-        ...
+        raise NotImplemented
 
     @property
     def models(self) -> Iterable[Type[BaseModel]]:
-        ...
+        raise NotImplemented
 
     def generate_spec(self) -> Mapping[str, Any]:
-        ...
+        raise NotImplemented
 
 
 class Response(ResponseBase):
@@ -131,10 +131,10 @@ class FileResponse(ResponseBase):
 
 class RequestBase:
     def has_model(self) -> bool:
-        ...
+        raise NotImplemented
 
     def generate_spec(self) -> Mapping[str, Any]:
-        ...
+        raise NotImplemented
 
 
 class Request(RequestBase):

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -203,9 +203,13 @@ def parse_multi_dict(input: MultiDict) -> Dict[str, Any]:
     result = {}
     for key, value in input.to_dict(flat=False).items():
         if len(value) == 1:
-            result[key] = value[0]
+            try:
+                value_to_use = json.loads(value[0])
+            except (TypeError, JSONDecodeError):
+                value_to_use = value[0]
         else:
-            result[key] = value
+            value_to_use = value
+        result[key] = value_to_use
     return result
 
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,8 +1,9 @@
 -r production.txt
-openapi-spec-validator >=0.2.9, <0.3
-pytest >=6.0.1, <7
-flake8 >=4.0.1, <5
-flask >=2.0.2, <3
-requests >=2.24.0, <3
-black >=20.8b1
-mypy==0.812
+openapi-spec-validator>=0.2.9, <0.3
+pytest>=6.0.1, <7
+flake8>=4.0.1, <5
+flask>=2.0.2, <3
+werkzeug==2.1.2
+requests>=2.24.0, <3
+black>=20.8b1
+mypy==0.971

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -3,7 +3,6 @@ openapi-spec-validator>=0.2.9, <0.3
 pytest>=6.0.1, <7
 flake8>=4.0.1, <5
 flask>=2.0.2, <3
-werkzeug==2.1.2
 requests>=2.24.0, <3
 black>=20.8b1
 mypy==0.971

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,11 @@ setup(
     package_data={},
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, "requirements/production.txt"), encoding="utf-8") as f
 
 setup(
     name="flask_pydantic_spec",
-    version="0.4.0",
+    version="0.4.1",
     author="Chris Gearing, Simon Hayward, Rob Young, Donald Fleming, Saurabh Jha",
     author_email="chris.gearing@turntown.digital",
     description=(

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, "requirements/production.txt"), encoding="utf-8") as f
 
 setup(
     name="flask_pydantic_spec",
-    version="0.3.1",
+    version="0.4.0",
     author="Chris Gearing, Simon Hayward, Rob Young, Donald Fleming, Saurabh Jha",
     author_email="chris.gearing@turntown.digital",
     description=(
@@ -36,7 +36,7 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=requires,
     extras_require={
         "flask": ["flask"],

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,3 +1,4 @@
+from datetime import date
 from enum import IntEnum, Enum
 from typing import List, Optional
 
@@ -43,7 +44,7 @@ class Language(str, Enum):
 class Headers(BaseModel):
     lang: Language
 
-    @root_validator(pre=True)
+    @root_validator(pre=True, allow_reuse=True)
     def lower_keys(cls, values):
         return {key.lower(): value for key, value in values.items()}
 
@@ -58,8 +59,14 @@ class DemoModel(BaseModel):
     name: str
 
 
+class FileMetadata(BaseModel):
+    type: str
+    created_at: date
+
+
 class FileName(BaseModel):
     file_name: str
+    data: FileMetadata
 
 
 def get_paths(spec):

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from io import BytesIO
 from random import randint
 import gzip
@@ -166,7 +167,13 @@ def test_sending_file(client):
     file = FileStorage(BytesIO(b"abcde"), filename="test.jpg", name="test.jpg")
     resp = client.post(
         "/api/file",
-        data={"file": file, "file_name": "another_test.jpg"},
+        data={
+            "file": file,
+            "file_name": "another_test.jpg",
+            "data": json.dumps(
+                {"type": "foo", "created_at": str(datetime.now().date())}
+            ),
+        },
         content_type="multipart/form-data",
     )
     assert resp.status_code == 200


### PR DESCRIPTION
### Purpose

Part of [this effort](https://github.com/verkada/Verkada-Backend/pull/62966) to upgrade `flask_pydantic_spec` in Verkada-Backend.

> `flask_pydantic_spec==0.3.1` and `werkzeug==2.2.3` are incompatible. `werkzeug` removed the function `werkzeug.routing.parse_rule` in 2.2.0, which is addressed in [this commit](https://github.com/turner-townsend/flask-pydantic-spec/commit/a71663ef997c977c9a319c111e3257db044b1b24#diff-dea0e51274bd1040d7b5bbbb35d76d192f3cf771e2750a67755bf93f1f139fabR228). This commit is included in `flask_pydantic_spec==0.4.1`, so we should upgrade the package to that version at least.
> 
> Looking at the [changelog](https://github.com/turner-townsend/flask-pydantic-spec/blob/main/CHANGES.rst#version-041), the only breaking change is dropping support for Python 3.6