### PR TITLE
add option for route to not require api key

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -359,7 +359,9 @@ class FlaskPydanticSpec:
                     )
                     publish = self.class_view_apispec[path][method.lower()]["publish"]
                     category = self.class_view_apispec[path][method.lower()]["category"]
-                    no_api_key = self.class_view_apispec[path][method.lower()].get("no_api_key", False)
+                    no_api_key = self.class_view_apispec[path][method.lower()].get(
+                        "no_api_key", False
+                    )
                     if self.config.MODE == "publish_only" and not publish:
                         continue
                 else:
@@ -389,7 +391,9 @@ class FlaskPydanticSpec:
                 if path not in self.routes_by_category[category]:
                     self.routes_by_category[category][path] = dict()
 
-                self.routes_by_category[category][path][method.lower()] = path_method_info
+                self.routes_by_category[category][path][
+                    method.lower()
+                ] = path_method_info
                 if hasattr(func, "deprecated"):
                     routes[path][method.lower()]["deprecated"] = True
 

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -379,7 +379,7 @@ class FlaskPydanticSpec:
                     "tags": func_tag,
                     "parameters": parameters,
                     "responses": responses,
-                    **({} if no_api_key else {"security": []}),
+                    **({"security": []} if no_api_key else {}),
                 }
                 routes[path][method.lower()] = path_method_info
 

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -150,7 +150,7 @@ class FlaskPydanticSpec:
         after: Optional[Callable] = None,
         publish: bool = False,
         category: str = "default",
-        no_api_key: bool = True,
+        no_api_key: bool = False,
     ) -> Callable:
         """
         - validate query, body, headers in request

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -150,6 +150,7 @@ class FlaskPydanticSpec:
         after: Optional[Callable] = None,
         publish: bool = False,
         category: str = "default",
+        no_api_key: bool = True,
     ) -> Callable:
         """
         - validate query, body, headers in request
@@ -203,6 +204,7 @@ class FlaskPydanticSpec:
                 self.class_view_api_info[view_name][method]["responses"] = {
                     "200": {"description": "ok"}
                 }
+                self.class_view_api_info[view_name][method]["no_api_key"] = no_api_key
 
             # register
             for name, model in zip(
@@ -357,6 +359,7 @@ class FlaskPydanticSpec:
                     )
                     publish = self.class_view_apispec[path][method.lower()]["publish"]
                     category = self.class_view_apispec[path][method.lower()]["category"]
+                    no_api_key = self.class_view_apispec[path][method.lower()].get("no_api_key", False)
                     if self.config.MODE == "publish_only" and not publish:
                         continue
                 else:
@@ -364,17 +367,21 @@ class FlaskPydanticSpec:
                     if self.bypass_unpublish(func):
                         continue
                     category = getattr(func, "category", "default")
+                    no_api_key = getattr(func, "no_api_key", False)
 
                 if path not in routes:
                     routes[path] = dict()
-                routes[path][method.lower()] = {
+
+                path_method_info = {
                     "summary": summary or f"{name} <{method}>",
                     "operationId": operation_id,
                     "description": desc or "",
                     "tags": func_tag,
                     "parameters": parameters,
                     "responses": responses,
+                    **({} if no_api_key else {"security": []}),
                 }
+                routes[path][method.lower()] = path_method_info
 
                 if category not in self.routes_by_category:
                     self.routes_by_category[category] = dict()
@@ -382,15 +389,7 @@ class FlaskPydanticSpec:
                 if path not in self.routes_by_category[category]:
                     self.routes_by_category[category][path] = dict()
 
-                self.routes_by_category[category][path][method.lower()] = {
-                    "summary": summary or f"{name} <{method}>",
-                    "operationId": operation_id,
-                    "description": desc or "",
-                    "tags": func_tag,
-                    "parameters": parameters,
-                    "responses": responses,
-                }
-
+                self.routes_by_category[category][path][method.lower()] = path_method_info
                 if hasattr(func, "deprecated"):
                     routes[path][method.lower()]["deprecated"] = True
 


### PR DESCRIPTION
We have a route for streaming, `/stream/cameras/v1/footage/stream/<key>`, that does not enforce API key. However, all routes displayed in the API docs say they enforce API key, and we define API key as the default security scheme. This PR will add an option in the `@openapi.validate()` method, `no_api_key`, to specify if a route does not require an API key.