### PR TITLE
Fix bug where query parameter string could get parsed as number

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -151,7 +151,7 @@ class FlaskBackend:
                     {} if request.get_data() == b"" else request.get_json(force=True)
                 )
         elif request.content_type and "multipart/form-data" in request.content_type:
-            parsed_body = parse_multi_dict(request.form) if request.form else {}
+            parsed_body = parse_multi_dict(request.form, parse_json=True) if request.form else {}
         else:
             parsed_body = request.get_data() or {}
         req_headers: Optional[Headers] = request.headers or None

--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -151,7 +151,9 @@ class FlaskBackend:
                     {} if request.get_data() == b"" else request.get_json(force=True)
                 )
         elif request.content_type and "multipart/form-data" in request.content_type:
-            parsed_body = parse_multi_dict(request.form, parse_json=True) if request.form else {}
+            parsed_body = (
+                parse_multi_dict(request.form, parse_json=True) if request.form else {}
+            )
         else:
             parsed_body = request.get_data() or {}
         req_headers: Optional[Headers] = request.headers or None

--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -137,7 +137,7 @@ class FlaskBackend:
     ) -> None:
         raw_query = request.args or None
         if raw_query is not None:
-            req_query = parse_multi_dict(raw_query, parse_json=False)
+            req_query = parse_multi_dict(raw_query, False)
         else:
             req_query = {}
         if request.content_type and "application/json" in request.content_type:
@@ -152,7 +152,7 @@ class FlaskBackend:
                 )
         elif request.content_type and "multipart/form-data" in request.content_type:
             parsed_body = (
-                parse_multi_dict(request.form, parse_json=True) if request.form else {}
+                parse_multi_dict(request.form, True) if request.form else {}
             )
         else:
             parsed_body = request.get_data() or {}

--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -137,7 +137,7 @@ class FlaskBackend:
     ) -> None:
         raw_query = request.args or None
         if raw_query is not None:
-            req_query = parse_multi_dict(raw_query)
+            req_query = parse_multi_dict(raw_query, parse_json=False)
         else:
             req_query = {}
         if request.content_type and "application/json" in request.content_type:

--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -137,7 +137,7 @@ class FlaskBackend:
     ) -> None:
         raw_query = request.args or None
         if raw_query is not None:
-            req_query = parse_multi_dict(raw_query, False)
+            req_query = parse_multi_dict(raw_query)
         else:
             req_query = {}
         if request.content_type and "application/json" in request.content_type:
@@ -152,7 +152,7 @@ class FlaskBackend:
                 )
         elif request.content_type and "multipart/form-data" in request.content_type:
             parsed_body = (
-                parse_multi_dict(request.form, True) if request.form else {}
+                parse_multi_dict(request.form, parse_json=True) if request.form else {}
             )
         else:
             parsed_body = request.get_data() or {}

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -197,7 +197,7 @@ def default_after_handler(
         )
 
 
-def parse_multi_dict(input: MultiDict, parse_json=False) -> Dict[str, Any]:
+def parse_multi_dict(input: MultiDict, parse_json: bool = False) -> Dict[str, Any]:
     result = {}
     for key, value in input.to_dict(flat=False).items():
         if len(value) == 1 and parse_json:

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -197,7 +197,7 @@ def default_after_handler(
         )
 
 
-def parse_multi_dict(input: MultiDict, parse_json: bool = False) -> Dict[str, Any]:
+def parse_multi_dict(input: MultiDict, parse_json: bool) -> Dict[str, Any]:
     result = {}
     for key, value in input.to_dict(flat=False).items():
         if len(value) == 1 and parse_json:

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -197,14 +197,16 @@ def default_after_handler(
         )
 
 
-def parse_multi_dict(input: MultiDict) -> Dict[str, Any]:
+def parse_multi_dict(input: MultiDict, parse_json=False) -> Dict[str, Any]:
     result = {}
     for key, value in input.to_dict(flat=False).items():
-        if len(value) == 1:
+        if len(value) == 1 and parse_json:
             try:
                 value_to_use = json.loads(value[0])
             except (TypeError, JSONDecodeError):
                 value_to_use = value[0]
+        elif len(value) == 1:
+            value_to_use = value[0]
         else:
             value_to_use = value
         result[key] = value_to_use

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -197,7 +197,7 @@ def default_after_handler(
         )
 
 
-def parse_multi_dict(input: MultiDict, parse_json: bool) -> Dict[str, Any]:
+def parse_multi_dict(input: MultiDict, parse_json: bool = False) -> Dict[str, Any]:
     result = {}
     for key, value in input.to_dict(flat=False).items():
         if len(value) == 1 and parse_json:


### PR DESCRIPTION
There is some logic that will call `json.loads` on the query param fields, so if the string resembles a number, specifically ones with notation like `136e32`, it will be parsed as a number.