### PR TITLE
Update to Pydantic v1.10.21 and import from `pydantic.v1`

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -5,7 +5,6 @@ import logging
 from typing import Optional, Mapping, Callable, Any, Tuple, List, Type, Iterable, Dict
 from dataclasses import dataclass
 
-from pydantic import ValidationError, BaseModel
 from flask import (
     request,
     abort,
@@ -15,6 +14,7 @@ from flask import (
     Flask,
     Response as FlaskResponse,
 )
+from pydantic.v1 import BaseModel, ValidationError
 from werkzeug.datastructures import Headers
 from werkzeug.routing import Rule, parse_converter_args
 

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -3,9 +3,9 @@ from functools import wraps
 from typing import Mapping, Optional, Type, Union, Callable, Iterable, Any, Dict, cast
 
 from flask import Flask, Response as FlaskResponse
-from pydantic import BaseModel
 from inflection import camelize
 from nested_lookup import nested_alter
+from pydantic.v1 import BaseModel
 
 from . import Request
 from .config import Config

--- a/flask_pydantic_spec/types.py
+++ b/flask_pydantic_spec/types.py
@@ -1,7 +1,7 @@
 import re
 from typing import Optional, Type, Iterable, Mapping, Any, Dict, List
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class ResponseBase:

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -16,9 +16,9 @@ from typing import (
     Type,
 )
 
+from pydantic.v1 import BaseModel
+from pydantic.v1.fields import SHAPE_DICT, SHAPE_LIST
 from werkzeug.datastructures import MultiDict
-from pydantic import BaseModel
-from pydantic.fields import SHAPE_LIST, SHAPE_DICT
 from werkzeug.routing import Rule
 
 from .types import Response, RequestBase, Request

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,3 @@
-pydantic==1.10.11
+pydantic==1.10.21
 inflection==0.5.1
 nested_lookup==0.2.25

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,7 @@ from datetime import date
 from enum import IntEnum, Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, root_validator
+from pydantic.v1 import BaseModel, root_validator
 
 
 class Order(IntEnum):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -5,7 +5,7 @@ import pytest
 from flask import Flask
 from typing import List
 from openapi_spec_validator import validate_v3_spec
-from pydantic import BaseModel, StrictFloat, Field
+from pydantic.v1 import BaseModel, Field, StrictFloat
 
 from flask_pydantic_spec import Response
 from flask_pydantic_spec.flask_backend import FlaskBackend


### PR DESCRIPTION
Starting in Pydantic v1.10.17, `pydantic.v1` was introduced as a compatibility layer for upgrading to Pydantic v2. By importing from `pydantic.v1`, we can continue using the Pydantic v1 semantics while having Pydantic v2 installed. Once everything is using Pydantic v2, this package can be updated to utilize the Pydantic v2 syntax and features when desired.